### PR TITLE
Add Amazon SP API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # codex5
 
-This repository contains a simple Python script to retrieve renewed smartphone data from the Keepa API.
+This repository contains example Python scripts that interact with ecommerce APIs.
+
+- `keepa_renewed_smartphones.py` retrieves renewed smartphone data from the Keepa API.
+- `amazon_reports.py` shows how to fetch order information from the Amazon Selling Partner API and summarise revenue and best sellers for the last year.
 
 ## Requirements
 
@@ -10,7 +13,11 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+The Amazon SP API requires additional credentials. See the script for environment variables that need to be set.
+
 ## Usage
+
+### Keepa example
 
 Provide your Keepa API key via environment variable or command-line argument:
 
@@ -25,5 +32,18 @@ or
 python3 keepa_renewed_smartphones.py your_api_key
 ```
 
-The script queries Keepa for "renewed smartphone" and prints the product title and ASIN for each result.
+### Amazon reports example
 
+Set the SP API credentials in environment variables:
+
+```bash
+export SP_REFRESH_TOKEN="..."
+export SP_LWA_APP_ID="..."
+export SP_LWA_CLIENT_SECRET="..."
+export SP_AWS_ACCESS_KEY="..."
+export SP_AWS_SECRET_KEY="..."
+export SP_ROLE_ARN="..."
+python3 amazon_reports.py
+```
+
+The Amazon script prints total revenue and best sellers for the last year. Returns and claims reporting are left as an exercise for the user.

--- a/amazon_reports.py
+++ b/amazon_reports.py
@@ -1,0 +1,92 @@
+import os
+import datetime
+from typing import List, Dict
+
+# The sp-api library must be installed separately.
+try:
+    from sp_api.api import Orders, Reports, Sellers
+    from sp_api.base import SellingApiException
+except ImportError:  # pragma: no cover - library might not be installed in test env
+    Orders = Reports = Sellers = None  # type: ignore
+    SellingApiException = Exception  # type: ignore
+
+
+def get_credentials() -> Dict[str, str]:
+    """Load SP API credentials from environment variables."""
+    return {
+        "refresh_token": os.environ.get("SP_REFRESH_TOKEN", ""),
+        "lwa_app_id": os.environ.get("SP_LWA_APP_ID", ""),
+        "lwa_client_secret": os.environ.get("SP_LWA_CLIENT_SECRET", ""),
+        "aws_access_key": os.environ.get("SP_AWS_ACCESS_KEY", ""),
+        "aws_secret_key": os.environ.get("SP_AWS_SECRET_KEY", ""),
+        "role_arn": os.environ.get("SP_ROLE_ARN", ""),
+    }
+
+
+def fetch_orders(credentials: Dict[str, str], start: datetime.datetime, end: datetime.datetime) -> List[Dict]:
+    """Fetch orders between start and end dates."""
+    if Orders is None:
+        raise RuntimeError("sp-api library not available")
+    api = Orders(credentials=credentials)
+    orders = []
+    token = None
+    while True:
+        try:
+            data = api.get_orders(CreatedAfter=start.isoformat(), CreatedBefore=end.isoformat(), NextToken=token)
+        except SellingApiException as exc:  # pragma: no cover - network call
+            print(f"Failed to fetch orders: {exc}")
+            break
+        orders.extend(data.payload.get("Orders", []))
+        token = data.payload.get("NextToken")
+        if not token:
+            break
+    return orders
+
+
+def summarize_profit(orders: List[Dict]) -> float:
+    """Compute total order revenue.
+
+    This is a simplified calculation. Real profit should account for fees and costs.
+    """
+    total = 0.0
+    for order in orders:
+        amounts = order.get("OrderTotal", {})
+        total += float(amounts.get("Amount", 0.0))
+    return total
+
+
+def summarize_best_sellers(orders: List[Dict]) -> Dict[str, int]:
+    """Count order lines per ASIN."""
+    best = {}
+    for order in orders:
+        for item in order.get("OrderItems", []):
+            asin = item.get("ASIN")
+            quantity = int(item.get("QuantityOrdered", 0))
+            best[asin] = best.get(asin, 0) + quantity
+    return best
+
+
+def main() -> int:
+    credentials = get_credentials()
+    end = datetime.datetime.utcnow()
+    start = end - datetime.timedelta(days=365)
+
+    orders = fetch_orders(credentials, start, end)
+    print(f"Retrieved {len(orders)} orders")
+
+    profit = summarize_profit(orders)
+    print(f"Total revenue: ${profit:.2f}")
+
+    best = summarize_best_sellers(orders)
+    print("Best sellers:")
+    for asin, qty in sorted(best.items(), key=lambda x: x[1], reverse=True)[:10]:
+        print(f"  {asin}: {qty}")
+
+    # Placeholders for returns and claims reports. In a real application, you
+    # would query the appropriate SP API endpoints here.
+    print("Returns and claims reporting not implemented in this example.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.0
+sp-api>=0.5


### PR DESCRIPTION
## Summary
- add example script `amazon_reports.py` for Amazon Selling Partner API
- document new script usage
- list `sp-api` dependency

## Testing
- `python3 -m py_compile keepa_renewed_smartphones.py amazon_reports.py`
- `python3 amazon_reports.py` *(fails: sp-api library not available)*

------
https://chatgpt.com/codex/tasks/task_e_68784e1db1ec83268512902df89c06c7